### PR TITLE
OCALL Support

### DIFF
--- a/drivers/tee/optee/Makefile
+++ b/drivers/tee/optee/Makefile
@@ -4,3 +4,4 @@ optee-objs += core.o
 optee-objs += call.o
 optee-objs += rpc.o
 optee-objs += supp.o
+optee-objs += shm_pool.o

--- a/drivers/tee/optee/Makefile
+++ b/drivers/tee/optee/Makefile
@@ -5,3 +5,4 @@ optee-objs += call.o
 optee-objs += rpc.o
 optee-objs += supp.o
 optee-objs += shm_pool.o
+optee-objs += grpc.o

--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -11,11 +11,11 @@
  * GNU General Public License for more details.
  *
  */
-#include <asm/pgtable.h>
 #include <linux/arm-smccc.h>
 #include <linux/device.h>
 #include <linux/err.h>
 #include <linux/errno.h>
+#include <linux/mm.h>
 #include <linux/slab.h>
 #include <linux/tee_drv.h>
 #include <linux/types.h>

--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -536,7 +536,8 @@ void optee_free_pages_list(void *list, size_t num_entries)
 }
 
 int optee_shm_register(struct tee_context *ctx, struct tee_shm *shm,
-		       struct page **pages, size_t num_pages)
+		       struct page **pages, size_t num_pages,
+		       unsigned long start)
 {
 	struct tee_shm *shm_arg = NULL;
 	struct optee_msg_arg *msg_arg;
@@ -606,7 +607,8 @@ int optee_shm_unregister(struct tee_context *ctx, struct tee_shm *shm)
 }
 
 int optee_shm_register_supp(struct tee_context *ctx, struct tee_shm *shm,
-			    struct page **pages, size_t num_pages)
+			    struct page **pages, size_t num_pages,
+			    unsigned long start)
 {
 	/*
 	 * We don't want to register supplicant memory in OP-TEE.

--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -533,3 +533,72 @@ void optee_free_pages_list(void *list, size_t num_entries)
 	free_pages_exact(list, get_pages_list_size(num_entries));
 }
 
+int optee_shm_register(struct tee_context *ctx, struct tee_shm *shm,
+		       struct page **pages, size_t num_pages)
+{
+	struct tee_shm *shm_arg = NULL;
+	struct optee_msg_arg *msg_arg;
+	u64 *pages_list;
+	phys_addr_t msg_parg;
+	int rc = 0;
+
+	if (!num_pages)
+		return -EINVAL;
+
+	pages_list = optee_allocate_pages_list(num_pages);
+	if (!pages_list)
+		return -ENOMEM;
+
+	shm_arg = get_msg_arg(ctx, 1, &msg_arg, &msg_parg);
+	if (IS_ERR(shm_arg)) {
+		rc = PTR_ERR(shm_arg);
+		goto out;
+	}
+
+	optee_fill_pages_list(pages_list, pages, num_pages,
+			      tee_shm_get_page_offset(shm));
+
+	msg_arg->cmd = OPTEE_MSG_CMD_REGISTER_SHM;
+	msg_arg->params->attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT |
+				OPTEE_MSG_ATTR_NONCONTIG;
+	msg_arg->params->u.tmem.shm_ref = (unsigned long)shm;
+	msg_arg->params->u.tmem.size = tee_shm_get_size(shm);
+	/*
+	 * In the least bits of msg_arg->params->u.tmem.buf_ptr we
+	 * store buffer offset from 4k page, as described in OP-TEE ABI.
+	 */
+	msg_arg->params->u.tmem.buf_ptr = virt_to_phys(pages_list) |
+	  (tee_shm_get_page_offset(shm) & (OPTEE_MSG_NONCONTIG_PAGE_SIZE - 1));
+
+	if (optee_do_call_with_arg(ctx, msg_parg) ||
+	    msg_arg->ret != TEEC_SUCCESS)
+		rc = -EINVAL;
+
+	tee_shm_free(shm_arg);
+out:
+	optee_free_pages_list(pages_list, num_pages);
+	return rc;
+}
+
+int optee_shm_unregister(struct tee_context *ctx, struct tee_shm *shm)
+{
+	struct tee_shm *shm_arg;
+	struct optee_msg_arg *msg_arg;
+	phys_addr_t msg_parg;
+	int rc = 0;
+
+	shm_arg = get_msg_arg(ctx, 1, &msg_arg, &msg_parg);
+	if (IS_ERR(shm_arg))
+		return PTR_ERR(shm_arg);
+
+	msg_arg->cmd = OPTEE_MSG_CMD_UNREGISTER_SHM;
+
+	msg_arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_RMEM_INPUT;
+	msg_arg->params[0].u.rmem.shm_ref = (unsigned long)shm;
+
+	if (optee_do_call_with_arg(ctx, msg_parg) ||
+	    msg_arg->ret != TEEC_SUCCESS)
+		rc = -EINVAL;
+	tee_shm_free(shm_arg);
+	return rc;
+}

--- a/drivers/tee/optee/call.c
+++ b/drivers/tee/optee/call.c
@@ -136,6 +136,7 @@ u32 optee_do_call_with_arg(struct tee_context *ctx, phys_addr_t parg)
 	struct optee *optee = tee_get_drvdata(ctx->teedev);
 	struct optee_call_waiter w;
 	struct optee_rpc_param param = { };
+	struct optee_call_ctx call_ctx = { };
 	u32 ret;
 
 	param.a0 = OPTEE_SMC_CALL_WITH_ARG;
@@ -160,13 +161,14 @@ u32 optee_do_call_with_arg(struct tee_context *ctx, phys_addr_t parg)
 			param.a1 = res.a1;
 			param.a2 = res.a2;
 			param.a3 = res.a3;
-			optee_handle_rpc(ctx, &param);
+			optee_handle_rpc(ctx, &param, &call_ctx);
 		} else {
 			ret = res.a0;
 			break;
 		}
 	}
 
+	optee_rpc_finalize_call(&call_ctx);
 	/*
 	 * We're done with our thread in secure world, if there's any
 	 * thread waiters wake up one.
@@ -601,4 +603,19 @@ int optee_shm_unregister(struct tee_context *ctx, struct tee_shm *shm)
 		rc = -EINVAL;
 	tee_shm_free(shm_arg);
 	return rc;
+}
+
+int optee_shm_register_supp(struct tee_context *ctx, struct tee_shm *shm,
+			    struct page **pages, size_t num_pages)
+{
+	/*
+	 * We don't want to register supplicant memory in OP-TEE.
+	 * Instead information about it will be passed in RPC code.
+	 */
+	return 0;
+}
+
+int optee_shm_unregister_supp(struct tee_context *ctx, struct tee_shm *shm)
+{
+	return 0;
 }

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -187,12 +187,12 @@ static int optee_open(struct tee_context *ctx)
 	if (teedev == optee->supp_teedev) {
 		bool busy = true;
 
-		mutex_lock(&optee->supp.ctx_mutex);
+		mutex_lock(&optee->supp.mutex);
 		if (!optee->supp.ctx) {
 			busy = false;
 			optee->supp.ctx = ctx;
 		}
-		mutex_unlock(&optee->supp.ctx_mutex);
+		mutex_unlock(&optee->supp.mutex);
 		if (busy) {
 			kfree(ctxdata);
 			return -EBUSY;
@@ -252,11 +252,8 @@ static void optee_release(struct tee_context *ctx)
 
 	ctx->data = NULL;
 
-	if (teedev == optee->supp_teedev) {
-		mutex_lock(&optee->supp.ctx_mutex);
-		optee->supp.ctx = NULL;
-		mutex_unlock(&optee->supp.ctx_mutex);
-	}
+	if (teedev == optee->supp_teedev)
+		optee_supp_release(&optee->supp);
 }
 
 static const struct tee_driver_ops optee_ops = {

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -542,6 +542,7 @@ static struct optee *optee_probe(struct device_node *np)
 	}
 
 	optee->invoke_fn = invoke_fn;
+	optee->sec_caps = sec_caps;
 
 	teedev = tee_device_alloc(&optee_desc, NULL, pool, optee);
 	if (IS_ERR(teedev)) {

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -328,6 +328,8 @@ static const struct tee_driver_ops optee_supp_ops = {
 	.release = optee_release,
 	.supp_recv = optee_supp_recv,
 	.supp_send = optee_supp_send,
+	.shm_register = optee_shm_register_supp,
+	.shm_unregister = optee_shm_unregister_supp,
 };
 
 static const struct tee_desc optee_supp_desc = {

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -264,6 +264,8 @@ static const struct tee_driver_ops optee_ops = {
 	.close_session = optee_close_session,
 	.invoke_func = optee_invoke_func,
 	.cancel_req = optee_cancel_req,
+	.shm_register = optee_shm_register,
+	.shm_unregister = optee_shm_unregister,
 };
 
 static const struct tee_desc optee_desc = {

--- a/drivers/tee/optee/core.c
+++ b/drivers/tee/optee/core.c
@@ -319,6 +319,8 @@ static const struct tee_driver_ops optee_ops = {
 	.cancel_req = optee_cancel_req,
 	.shm_register = optee_shm_register,
 	.shm_unregister = optee_shm_unregister,
+	.grpc_recv = optee_grpc_recv,
+	.grpc_send = optee_grpc_send,
 };
 
 static const struct tee_desc optee_desc = {

--- a/drivers/tee/optee/grpc.c
+++ b/drivers/tee/optee/grpc.c
@@ -4,7 +4,6 @@
 struct optee_grpc_req {
 	struct list_head link;
 
-	u32 key;
 	u32 func;
 	u32 session_id;
 	u32 ret;
@@ -30,8 +29,8 @@ void optee_grpc_uninit(struct optee_grpc *grpc)
 	idr_destroy(&grpc->idr);
 }
 
-noinline u32 optee_grpc_req(struct optee_session *sess, u32 key, u32 func, size_t num_params,
-		      struct tee_param *param)
+u32 optee_grpc_req(struct optee_session *sess, u32 func, size_t num_params,
+		   struct tee_param *param)
 {
 	struct optee_grpc_req *req;
 	u32 ret;
@@ -42,7 +41,6 @@ noinline u32 optee_grpc_req(struct optee_session *sess, u32 key, u32 func, size_
 	}
 
 	init_completion(&req->c);
-	req->key = key;
 	req->func = func;
 	req->session_id = sess->session_id;
 	req->num_params = num_params;
@@ -90,7 +88,7 @@ static struct optee_grpc_req *grpc_pop_entry(struct optee_session *sess,
 	return req;
 }
 
-int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 *num_params,
+int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *func, u32 *num_params,
 		    struct tee_param *param)
 {
 	struct optee_context_data *ctxdata = ctx->data;
@@ -123,7 +121,6 @@ int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u
 	sess->grpc.req_id = id;
 	mutex_unlock(&sess->grpc.mutex);
 
-	*key = req->key;
 	*func = req->func;
 	*num_params = req->num_params;
 	memcpy(param, req->param,
@@ -158,7 +155,7 @@ static struct optee_grpc_req *grpc_pop_req(struct optee_session *sess,
 	return req;
 }
 
-int optee_grpc_send(struct tee_context *ctx, u32 session, u32 key, u32 ret, u32 num_params,
+int optee_grpc_send(struct tee_context *ctx, u32 session, u32 ret, u32 num_params,
 		    struct tee_param *param)
 {
 	struct optee_context_data *ctxdata = ctx->data;

--- a/drivers/tee/optee/grpc.c
+++ b/drivers/tee/optee/grpc.c
@@ -1,0 +1,137 @@
+#include <linux/slab.h>
+#include "optee_private.h"
+
+struct optee_grpc_req {
+	struct list_head link;
+
+	u32 key;
+	u32 func;
+	u32 session_id;
+	u32 ret;
+	size_t num_params;
+	struct tee_param *param;
+
+	struct completion c;
+};
+
+void optee_grpc_init(struct optee_grpc *grpc)
+{
+	memset(grpc, 0, sizeof(*grpc));
+	mutex_init(&grpc->mutex);
+	init_completion(&grpc->reqs_c);
+	idr_init(&grpc->idr);
+	INIT_LIST_HEAD(&grpc->reqs);
+	grpc->req_id = -1;
+}
+
+void optee_grpc_uninit(struct optee_grpc *grpc)
+{
+	mutex_destroy(&grpc->mutex);
+	idr_destroy(&grpc->idr);
+}
+
+u32 optee_grpc_req(struct optee_session *sess, u32 key, u32 func, size_t num_params,
+		      struct tee_param *param)
+{
+	struct optee_grpc_req *req;
+	u32 ret;
+
+	req = kzalloc(sizeof(*req), GFP_KERNEL);
+	if (!req) {
+		return TEEC_ERROR_OUT_OF_MEMORY;
+	}
+
+	init_completion(&req->c);
+	req->key = key;
+	req->func = func;
+	req->session_id = sess->session_id;
+	req->num_params = num_params;
+	req->param = param;
+
+	mutex_lock(&sess->grpc.mutex);
+	list_add_tail(&req->link, &sess->grpc.reqs);
+	mutex_unlock(&sess->grpc.mutex);
+
+	complete(&sess->grpc.reqs_c);
+
+	if (wait_for_completion_interruptible(&req->c))
+		req->ret = TEEC_ERROR_COMMUNICATION;
+
+	ret = req->ret;
+	kfree(req);
+
+	return ret;
+}
+
+static struct optee_grpc_req *grpc_pop_entry(struct optee_session *sess,
+					      u32 num_params, int *id)
+{
+	struct optee_grpc_req *req;
+
+	if (sess->grpc.req_id != -1)
+		return ERR_PTR(-EINVAL);
+	
+	if (list_empty(&sess->grpc.reqs))
+		return NULL;
+	
+	req = list_first_entry(&sess->grpc.reqs, struct optee_grpc_req, link);
+
+	if (num_params < req->num_params) {
+		return ERR_PTR(-EINVAL);
+	}
+
+	*id = idr_alloc(&sess->grpc.idr, req, 1, 0, GFP_KERNEL);
+	if (*id < 0)
+		return ERR_PTR(-ENOMEM);
+	
+	list_del(&req->link);
+
+	return req;
+}
+
+int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 num_params,
+				struct tee_param *param)
+{
+	struct optee_context_data *ctxdata = ctx->data;
+	struct optee_session *sess;
+	struct optee_grpc_req *req;
+	int id;
+
+	mutex_lock(&ctxdata->mutex);
+	sess = optee_find_session(ctxdata, session);
+	mutex_unlock(&ctxdata->mutex);
+	if (!sess)
+		return -EINVAL;
+	
+	while (true) {
+		mutex_lock(&sess->grpc.mutex);
+		req = grpc_pop_entry(sess, num_params, &id);
+		mutex_unlock(&sess->grpc.mutex);
+
+		if (req) {
+			if (IS_ERR(req))
+				return PTR_ERR(req);
+			break;
+		}
+
+		if (wait_for_completion_interruptible(&sess->grpc.reqs_c))
+			return -ERESTARTSYS;
+	}
+
+	mutex_lock(&sess->grpc.mutex);
+	sess->grpc.req_id = id;
+	mutex_unlock(&sess->grpc.mutex);
+
+	*key = req->key;
+	*func = req->func;
+	memcpy(param, req->param,
+		   sizeof(struct tee_param) * req->num_params);
+
+	return 0;
+}
+
+int optee_grpc_send(struct tee_context *ctx, struct tee_ioctl_grpc_send_arg *arg,
+		      struct tee_param *param)
+{
+	return 1;
+}

--- a/drivers/tee/optee/optee_msg.h
+++ b/drivers/tee/optee/optee_msg.h
@@ -429,6 +429,8 @@ struct optee_msg_arg {
 #define OPTEE_MSG_RPC_SHM_TYPE_APPL	0
 /* Memory only shared with non-secure kernel */
 #define OPTEE_MSG_RPC_SHM_TYPE_KERNEL	1
+/* Memory shared with the non-secure user space  application that owns the current session */
+#define OPTEE_MSG_RPC_SHM_TYPE_HOST	3
 
 /*
  * Free shared memory previously allocated with OPTEE_MSG_RPC_CMD_SHM_ALLOC
@@ -440,5 +442,7 @@ struct optee_msg_arg {
  *					above
  */
 #define OPTEE_MSG_RPC_CMD_SHM_FREE	7
+
+#define OPTEE_MSG_RPC_CMD_GENERIC   11
 
 #endif /* _OPTEE_MSG_H */

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -53,36 +53,24 @@ struct optee_wait_queue {
  * @ctx			the context of current connected supplicant.
  *			if !NULL the supplicant device is available for use,
  *			else busy
- * @ctx_mutex:		held while accessing @ctx
- * @func:		supplicant function id to call
- * @ret:		call return value
- * @num_params:		number of elements in @param
- * @param:		parameters for @func
- * @req_posted:		if true, a request has been posted to the supplicant
- * @supp_next_send:	if true, next step is for supplicant to send response
- * @thrd_mutex:		held by the thread doing a request to supplicant
- * @supp_mutex:		held by supplicant while operating on this struct
- * @data_to_supp:	supplicant is waiting on this for next request
- * @data_from_supp:	requesting thread is waiting on this to get the result
+ * @mutex:		held while accessing content of this struct
+ * @req_id:		current request id if supplicant is doing synchronous
+ *			communication, else -1
+ * @reqs:		queued request not yet retrieved by supplicant
+ * @idr:		IDR holding all requests currently being processed
+ *			by supplicant
+ * @reqs_c:		completion used by supplicant when waiting for a
+ *			request to be queued.
  */
 struct optee_supp {
+	/* Serializes access to this struct */
+	struct mutex mutex;
 	struct tee_context *ctx;
-	/* Serializes access of ctx */
-	struct mutex ctx_mutex;
 
-	u32 func;
-	u32 ret;
-	size_t num_params;
-	struct tee_param *param;
-
-	bool req_posted;
-	bool supp_next_send;
-	/* Serializes access to this struct for requesting thread */
-	struct mutex thrd_mutex;
-	/* Serializes access to this struct for supplicant threads */
-	struct mutex supp_mutex;
-	struct completion data_to_supp;
-	struct completion data_from_supp;
+	int req_id;
+	struct list_head reqs;
+	struct idr idr;
+	struct completion reqs_c;
 };
 
 /**
@@ -142,6 +130,7 @@ int optee_supp_read(struct tee_context *ctx, void __user *buf, size_t len);
 int optee_supp_write(struct tee_context *ctx, void __user *buf, size_t len);
 void optee_supp_init(struct optee_supp *supp);
 void optee_supp_uninit(struct optee_supp *supp);
+void optee_supp_release(struct optee_supp *supp);
 
 int optee_supp_recv(struct tee_context *ctx, u32 *func, u32 *num_params,
 		    struct tee_param *param);

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -154,6 +154,11 @@ int optee_from_msg_param(struct tee_param *params, size_t num_params,
 int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,
 		       const struct tee_param *params);
 
+u64 *optee_allocate_pages_list(size_t num_entries);
+void optee_free_pages_list(void *array, size_t num_entries);
+void optee_fill_pages_list(u64 *dst, struct page **pages, int num_pages,
+			   size_t page_offset);
+
 /*
  * Small helpers
  */

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -118,7 +118,16 @@ struct optee_rpc_param {
 	u32	a7;
 };
 
-void optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param);
+/* Holds context that is preserved during one STD call */
+struct optee_call_ctx {
+	/* information about pages list used in last allocation */
+	void *pages_list;
+	size_t num_entries;
+};
+
+void optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param,
+		      struct optee_call_ctx *call_ctx);
+void optee_rpc_finalize_call(struct optee_call_ctx *call_ctx);
 
 void optee_wait_queue_init(struct optee_wait_queue *wq);
 void optee_wait_queue_exit(struct optee_wait_queue *wq);
@@ -152,6 +161,10 @@ void optee_disable_shm_cache(struct optee *optee);
 int optee_shm_register(struct tee_context *ctx, struct tee_shm *shm,
 		       struct page **pages, size_t num_pages);
 int optee_shm_unregister(struct tee_context *ctx, struct tee_shm *shm);
+
+int optee_shm_register_supp(struct tee_context *ctx, struct tee_shm *shm,
+			    struct page **pages, size_t num_pages);
+int optee_shm_unregister_supp(struct tee_context *ctx, struct tee_shm *shm);
 
 int optee_from_msg_param(struct tee_param *params, size_t num_params,
 			 const struct optee_msg_param *msg_params);

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -149,6 +149,10 @@ int optee_cancel_req(struct tee_context *ctx, u32 cancel_id, u32 session);
 void optee_enable_shm_cache(struct optee *optee);
 void optee_disable_shm_cache(struct optee *optee);
 
+int optee_shm_register(struct tee_context *ctx, struct tee_shm *shm,
+		       struct page **pages, size_t num_pages);
+int optee_shm_unregister(struct tee_context *ctx, struct tee_shm *shm);
+
 int optee_from_msg_param(struct tee_param *params, size_t num_params,
 			 const struct optee_msg_param *msg_params);
 int optee_to_msg_param(struct optee_msg_param *msg_params, size_t num_params,

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -84,6 +84,8 @@ struct optee_supp {
  * @supp:		supplicant synchronization struct for RPC to supplicant
  * @pool:		shared memory pool
  * @memremaped_shm	virtual address of memory in shared memory pool
+ * @sec_caps:		secure world capabilities defined by
+ *			OPTEE_SMC_SEC_CAP_* in optee_smc.h
  */
 struct optee {
 	struct tee_device *supp_teedev;
@@ -94,6 +96,7 @@ struct optee {
 	struct optee_supp supp;
 	struct tee_shm_pool *pool;
 	void *memremaped_shm;
+	u32 sec_caps;
 };
 
 struct optee_session {

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -162,11 +162,13 @@ void optee_enable_shm_cache(struct optee *optee);
 void optee_disable_shm_cache(struct optee *optee);
 
 int optee_shm_register(struct tee_context *ctx, struct tee_shm *shm,
-		       struct page **pages, size_t num_pages);
+		       struct page **pages, size_t num_pages,
+		       unsigned long start);
 int optee_shm_unregister(struct tee_context *ctx, struct tee_shm *shm);
 
 int optee_shm_register_supp(struct tee_context *ctx, struct tee_shm *shm,
-			    struct page **pages, size_t num_pages);
+			    struct page **pages, size_t num_pages,
+			    unsigned long start);
 int optee_shm_unregister_supp(struct tee_context *ctx, struct tee_shm *shm);
 
 int optee_from_msg_param(struct tee_param *params, size_t num_params,

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -186,12 +186,12 @@ int optee_shm_register_supp(struct tee_context *ctx, struct tee_shm *shm,
 			    unsigned long start);
 int optee_shm_unregister_supp(struct tee_context *ctx, struct tee_shm *shm);
 
-int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 *num_params,
+int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *func, u32 *num_params,
 		    struct tee_param *param);
-int optee_grpc_send(struct tee_context *ctx, u32 session, u32 key, u32 ret, u32 num_params,
+int optee_grpc_send(struct tee_context *ctx, u32 session, u32 ret, u32 num_params,
 		    struct tee_param *param);
 
-u32 optee_grpc_req(struct optee_session *sess, u32 key, u32 func, size_t num_params,
+u32 optee_grpc_req(struct optee_session *sess, u32 func, size_t num_params,
 		      struct tee_param *param);
 
 int optee_from_msg_param(struct tee_param *params, size_t num_params,

--- a/drivers/tee/optee/optee_private.h
+++ b/drivers/tee/optee/optee_private.h
@@ -186,10 +186,11 @@ int optee_shm_register_supp(struct tee_context *ctx, struct tee_shm *shm,
 			    unsigned long start);
 int optee_shm_unregister_supp(struct tee_context *ctx, struct tee_shm *shm);
 
-int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 num_params,
-				struct tee_param *param);
-int optee_grpc_send(struct tee_context *ctx, struct tee_ioctl_grpc_send_arg *arg,
-		      struct tee_param *param);
+int optee_grpc_recv(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 *num_params,
+		    struct tee_param *param);
+int optee_grpc_send(struct tee_context *ctx, u32 session, u32 key, u32 ret, u32 num_params,
+		    struct tee_param *param);
+
 u32 optee_grpc_req(struct optee_session *sess, u32 key, u32 func, size_t num_params,
 		      struct tee_param *param);
 

--- a/drivers/tee/optee/optee_smc.h
+++ b/drivers/tee/optee/optee_smc.h
@@ -112,11 +112,19 @@ struct optee_smc_calls_revision_result {
  * Trusted OS, not of the API.
  *
  * Returns revision in a0-1 in the same way as OPTEE_SMC_CALLS_REVISION
- * described above.
+ * described above. May optionally return a 32-bit build identifier in a2,
+ * with zero meaning unspecified.
  */
 #define OPTEE_SMC_FUNCID_GET_OS_REVISION OPTEE_MSG_FUNCID_GET_OS_REVISION
 #define OPTEE_SMC_CALL_GET_OS_REVISION \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_GET_OS_REVISION)
+
+struct optee_smc_call_get_os_revision_result {
+	unsigned long major;
+	unsigned long minor;
+	unsigned long build_id;
+	unsigned long reserved1;
+};
 
 /*
  * Call with struct optee_msg_arg as argument

--- a/drivers/tee/optee/optee_smc.h
+++ b/drivers/tee/optee/optee_smc.h
@@ -222,6 +222,13 @@ struct optee_smc_get_shm_config_result {
 #define OPTEE_SMC_SEC_CAP_HAVE_RESERVED_SHM	BIT(0)
 /* Secure world can communicate via previously unregistered shared memory */
 #define OPTEE_SMC_SEC_CAP_UNREGISTERED_SHM	BIT(1)
+
+/*
+ * Secure world supports commands "register/unregister shared memory",
+ * secure world accepts command buffers located in any parts of non-secure RAM
+ */
+#define OPTEE_SMC_SEC_CAP_DYNAMIC_SHM		BIT(2)
+
 #define OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES	9
 #define OPTEE_SMC_EXCHANGE_CAPABILITIES \
 	OPTEE_SMC_FAST_CALL_VAL(OPTEE_SMC_FUNCID_EXCHANGE_CAPABILITIES)

--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -192,10 +192,10 @@ static struct tee_shm *cmd_alloc_suppl(struct tee_context *ctx, size_t sz)
 	if (ret)
 		return ERR_PTR(-ENOMEM);
 
-	mutex_lock(&optee->supp.ctx_mutex);
+	mutex_lock(&optee->supp.mutex);
 	/* Increases count as secure world doesn't have a reference */
 	shm = tee_shm_get_from_id(optee->supp.ctx, param.u.value.c);
-	mutex_unlock(&optee->supp.ctx_mutex);
+	mutex_unlock(&optee->supp.mutex);
 	return shm;
 }
 

--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -200,7 +200,8 @@ static struct tee_shm *cmd_alloc_suppl(struct tee_context *ctx, size_t sz)
 }
 
 static void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
-					  struct optee_msg_arg *arg)
+					  struct optee_msg_arg *arg,
+					  struct optee_call_ctx *call_ctx)
 {
 	phys_addr_t pa;
 	struct tee_shm *shm;
@@ -245,10 +246,49 @@ static void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
 		goto bad;
 	}
 
-	arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
-	arg->params[0].u.tmem.buf_ptr = pa;
-	arg->params[0].u.tmem.size = sz;
-	arg->params[0].u.tmem.shm_ref = (unsigned long)shm;
+	sz = tee_shm_get_size(shm);
+
+	if (tee_shm_is_registered(shm)) {
+		struct page **pages;
+		u64 *pages_list;
+		size_t page_num;
+
+		pages = tee_shm_get_pages(shm, &page_num);
+		if (!pages || !page_num) {
+			arg->ret = TEEC_ERROR_OUT_OF_MEMORY;
+			goto bad;
+		}
+
+		pages_list = optee_allocate_pages_list(page_num);
+		if (!pages_list) {
+			arg->ret = TEEC_ERROR_OUT_OF_MEMORY;
+			goto bad;
+		}
+
+		call_ctx->pages_list = pages_list;
+		call_ctx->num_entries = page_num;
+
+		arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT |
+				      OPTEE_MSG_ATTR_NONCONTIG;
+		/*
+		 * In the least bits of u.tmem.buf_ptr we store buffer offset
+		 * from 4k page, as described in OP-TEE ABI.
+		 */
+		arg->params[0].u.tmem.buf_ptr = virt_to_phys(pages_list) |
+			(tee_shm_get_page_offset(shm) &
+			 (OPTEE_MSG_NONCONTIG_PAGE_SIZE - 1));
+		arg->params[0].u.tmem.size = tee_shm_get_size(shm);
+		arg->params[0].u.tmem.shm_ref = (unsigned long)shm;
+
+		optee_fill_pages_list(pages_list, pages, page_num,
+				      tee_shm_get_page_offset(shm));
+	} else {
+		arg->params[0].attr = OPTEE_MSG_ATTR_TYPE_TMEM_OUTPUT;
+		arg->params[0].u.tmem.buf_ptr = pa;
+		arg->params[0].u.tmem.size = sz;
+		arg->params[0].u.tmem.shm_ref = (unsigned long)shm;
+	}
+
 	arg->ret = TEEC_SUCCESS;
 	return;
 bad:
@@ -307,8 +347,24 @@ static void handle_rpc_func_cmd_shm_free(struct tee_context *ctx,
 	arg->ret = TEEC_SUCCESS;
 }
 
+static void free_pages_list(struct optee_call_ctx *call_ctx)
+{
+	if (call_ctx->pages_list) {
+		optee_free_pages_list(call_ctx->pages_list,
+				      call_ctx->num_entries);
+		call_ctx->pages_list = NULL;
+		call_ctx->num_entries = 0;
+	}
+}
+
+void optee_rpc_finalize_call(struct optee_call_ctx *call_ctx)
+{
+	free_pages_list(call_ctx);
+}
+
 static void handle_rpc_func_cmd(struct tee_context *ctx, struct optee *optee,
-				struct tee_shm *shm)
+				struct tee_shm *shm,
+				struct optee_call_ctx *call_ctx)
 {
 	struct optee_msg_arg *arg;
 
@@ -329,7 +385,8 @@ static void handle_rpc_func_cmd(struct tee_context *ctx, struct optee *optee,
 		handle_rpc_func_cmd_wait(arg);
 		break;
 	case OPTEE_MSG_RPC_CMD_SHM_ALLOC:
-		handle_rpc_func_cmd_shm_alloc(ctx, arg);
+		free_pages_list(call_ctx);
+		handle_rpc_func_cmd_shm_alloc(ctx, arg, call_ctx);
 		break;
 	case OPTEE_MSG_RPC_CMD_SHM_FREE:
 		handle_rpc_func_cmd_shm_free(ctx, arg);
@@ -343,10 +400,12 @@ static void handle_rpc_func_cmd(struct tee_context *ctx, struct optee *optee,
  * optee_handle_rpc() - handle RPC from secure world
  * @ctx:	context doing the RPC
  * @param:	value of registers for the RPC
+ * @call_ctx:	call context. Preserved during one OP-TEE invocation
  *
  * Result of RPC is written back into @param.
  */
-void optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param)
+void optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param,
+		      struct optee_call_ctx *call_ctx)
 {
 	struct tee_device *teedev = ctx->teedev;
 	struct optee *optee = tee_get_drvdata(teedev);
@@ -381,7 +440,7 @@ void optee_handle_rpc(struct tee_context *ctx, struct optee_rpc_param *param)
 		break;
 	case OPTEE_SMC_RPC_FUNC_CMD:
 		shm = reg_pair_to_ptr(param->a1, param->a2);
-		handle_rpc_func_cmd(ctx, optee, shm);
+		handle_rpc_func_cmd(ctx, optee, shm, call_ctx);
 		break;
 	default:
 		pr_warn("Unknown RPC func 0x%x\n",

--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -200,7 +200,8 @@ static struct tee_shm *cmd_alloc_suppl(struct tee_context *ctx, size_t sz)
 	return shm;
 }
 
-static struct tee_shm *cmd_alloc_host(struct tee_context *ctx, size_t sz, struct optee_session *session, uint64_t key)
+struct tee_shm *cmd_alloc_host(struct tee_context *ctx, size_t sz, struct optee_session *session, uint64_t key);
+noinline struct tee_shm *cmd_alloc_host(struct tee_context *ctx, size_t sz, struct optee_session *session, uint64_t key)
 {
 	u32 ret;
 	struct tee_param param;
@@ -223,7 +224,10 @@ static struct tee_shm *cmd_alloc_host(struct tee_context *ctx, size_t sz, struct
 	return shm;
 }
 
-static void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
+void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
+					  struct optee_msg_arg *arg,
+					  struct optee_call_ctx *call_ctx);
+noinline void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
 					  struct optee_msg_arg *arg,
 					  struct optee_call_ctx *call_ctx)
 {
@@ -491,7 +495,7 @@ noinline void handle_rpc_func_cmd_generic(struct tee_context *ctx,
 	}
 
 	key = (u32)params[0].u.value.c;
-	func = (u32)params[0].u.value.a;
+	func = arg->cmd;
 	
 	arg->ret = optee_grpc_req(sess, key, func, arg->num_params, params);
 
@@ -516,8 +520,10 @@ void optee_rpc_finalize_call(struct optee_call_ctx *call_ctx)
 {
 	free_pages_list(call_ctx);
 }
-
-static void handle_rpc_func_cmd(struct tee_context *ctx, struct optee *optee,
+void handle_rpc_func_cmd(struct tee_context *ctx, struct optee *optee,
+				struct tee_shm *shm,
+				struct optee_call_ctx *call_ctx);
+noinline void handle_rpc_func_cmd(struct tee_context *ctx, struct optee *optee,
 				struct tee_shm *shm,
 				struct optee_call_ctx *call_ctx)
 {

--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -455,11 +455,13 @@ static void handle_rpc_func_cmd_shm_free(struct tee_context *ctx,
 		}
 
 		cmd_free_host(shm, sess, arg->params[1].u.value.b);
+		break;
 	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
 		tee_shm_free(shm);
 		break;
 	default:
 		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+		break;
 	}
 	arg->ret = TEEC_SUCCESS;
 }

--- a/drivers/tee/optee/rpc.c
+++ b/drivers/tee/optee/rpc.c
@@ -176,6 +176,7 @@ out:
 	kfree(params);
 }
 
+
 static struct tee_shm *cmd_alloc_suppl(struct tee_context *ctx, size_t sz)
 {
 	u32 ret;
@@ -199,12 +200,37 @@ static struct tee_shm *cmd_alloc_suppl(struct tee_context *ctx, size_t sz)
 	return shm;
 }
 
+static struct tee_shm *cmd_alloc_host(struct tee_context *ctx, size_t sz, struct optee_session *session, uint64_t key)
+{
+	u32 ret;
+	struct tee_param param;
+	struct optee *optee = tee_get_drvdata(ctx->teedev);
+	struct tee_shm *shm;
+
+	param.attr = TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT;
+	param.u.value.a = OPTEE_MSG_RPC_SHM_TYPE_HOST;
+	param.u.value.b = sz;
+	param.u.value.c = 0;
+
+	ret = optee_grpc_req(session, key, OPTEE_MSG_RPC_CMD_SHM_ALLOC, 1, &param);
+	if (ret)
+		return ERR_PTR(-ENOMEM);
+
+	mutex_lock(&optee->supp.mutex);
+	/* Increases count as secure world doesn't have a reference */
+	shm = tee_shm_get_from_id(ctx, param.u.value.c);
+	mutex_unlock(&optee->supp.mutex);
+	return shm;
+}
+
 static void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
 					  struct optee_msg_arg *arg,
 					  struct optee_call_ctx *call_ctx)
 {
 	phys_addr_t pa;
 	struct tee_shm *shm;
+	struct optee_context_data *ctxdata = ctx->data;
+	struct optee_session *sess;
 	size_t sz;
 	size_t n;
 
@@ -216,17 +242,49 @@ static void handle_rpc_func_cmd_shm_alloc(struct tee_context *ctx,
 		return;
 	}
 
-	for (n = 1; n < arg->num_params; n++) {
-		if (arg->params[n].attr != OPTEE_MSG_ATTR_TYPE_NONE) {
+	switch (arg->params[0].u.value.a) {
+	case OPTEE_MSG_RPC_SHM_TYPE_APPL:
+	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
+		for (n = 1; n < arg->num_params; n++) {
+			if (arg->params[n].attr != OPTEE_MSG_ATTR_TYPE_NONE) {
+				arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+				return;
+			}
+		}
+		break;
+	case OPTEE_MSG_RPC_SHM_TYPE_HOST:
+		if(arg->params[1].attr != OPTEE_MSG_ATTR_TYPE_VALUE_INPUT) {
 			arg->ret = TEEC_ERROR_BAD_PARAMETERS;
 			return;
 		}
+
+		for (n = 2; n < arg->num_params; n++) {
+			if (arg->params[n].attr != OPTEE_MSG_ATTR_TYPE_NONE) {
+				arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+				return;
+			}
+		}
+		break;
+	default:
+		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+		return;
 	}
 
 	sz = arg->params[0].u.value.b;
 	switch (arg->params[0].u.value.a) {
 	case OPTEE_MSG_RPC_SHM_TYPE_APPL:
 		shm = cmd_alloc_suppl(ctx, sz);
+		break;
+	case OPTEE_MSG_RPC_SHM_TYPE_HOST:
+		mutex_lock(&ctxdata->mutex);
+		sess = optee_find_session(ctxdata, (u32)arg->params[1].u.value.a);
+		mutex_unlock(&ctxdata->mutex);
+		if (!sess) {
+			arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+			return;
+		}
+
+		shm = cmd_alloc_host(ctx, sz, sess, arg->params[1].u.value.b);
 		break;
 	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
 		shm = tee_shm_alloc(ctx, sz, TEE_SHM_MAPPED);
@@ -320,15 +378,60 @@ static void cmd_free_suppl(struct tee_context *ctx, struct tee_shm *shm)
 	optee_supp_thrd_req(ctx, OPTEE_MSG_RPC_CMD_SHM_FREE, 1, &param);
 }
 
+static void cmd_free_host(struct tee_shm *shm, struct optee_session *session, uint64_t key)
+{
+	struct tee_param param;
+
+	param.attr = TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT;
+	param.u.value.a = OPTEE_MSG_RPC_SHM_TYPE_HOST;
+	param.u.value.b = tee_shm_get_id(shm);
+	param.u.value.c = 0;
+
+	tee_shm_put(shm);
+
+	optee_grpc_req(session, key, OPTEE_MSG_RPC_CMD_SHM_FREE, 1, &param);
+}
+
 static void handle_rpc_func_cmd_shm_free(struct tee_context *ctx,
 					 struct optee_msg_arg *arg)
 {
 	struct tee_shm *shm;
+	struct optee_context_data *ctxdata = ctx->data;
+	struct optee_session *sess;
+	size_t n;
 
 	arg->ret_origin = TEEC_ORIGIN_COMMS;
 
-	if (arg->num_params != 1 ||
+	if (!arg->num_params ||
 	    arg->params[0].attr != OPTEE_MSG_ATTR_TYPE_VALUE_INPUT) {
+		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+		return;
+	}
+
+	switch (arg->params[0].u.value.a) {
+	case OPTEE_MSG_RPC_SHM_TYPE_APPL:
+	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
+		for (n = 1; n < arg->num_params; n++) {
+			if (arg->params[n].attr != OPTEE_MSG_ATTR_TYPE_NONE) {
+				arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+				return;
+			}
+		}
+		break;
+	case OPTEE_MSG_RPC_SHM_TYPE_HOST:
+		if(arg->params[1].attr != OPTEE_MSG_ATTR_TYPE_VALUE_INPUT) {
+			arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+			return;
+		}
+
+		for (n = 2; n < arg->num_params; n++) {
+			if (arg->params[n].attr != OPTEE_MSG_ATTR_TYPE_NONE) {
+				arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+				return;
+			}
+		}
+		break;
+	default:
 		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
 		return;
 	}
@@ -338,6 +441,16 @@ static void handle_rpc_func_cmd_shm_free(struct tee_context *ctx,
 	case OPTEE_MSG_RPC_SHM_TYPE_APPL:
 		cmd_free_suppl(ctx, shm);
 		break;
+	case OPTEE_MSG_RPC_SHM_TYPE_HOST:
+		mutex_lock(&ctxdata->mutex);
+		sess = optee_find_session(ctxdata, (u32)arg->params[1].u.value.a);
+		mutex_unlock(&ctxdata->mutex);
+		if (!sess) {
+			arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+			return;
+		}
+
+		cmd_free_host(shm, sess, arg->params[1].u.value.b);
 	case OPTEE_MSG_RPC_SHM_TYPE_KERNEL:
 		tee_shm_free(shm);
 		break;
@@ -345,6 +458,48 @@ static void handle_rpc_func_cmd_shm_free(struct tee_context *ctx,
 		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
 	}
 	arg->ret = TEEC_SUCCESS;
+}
+
+void handle_rpc_func_cmd_generic(struct tee_context *ctx, struct optee_msg_arg *arg);
+noinline void handle_rpc_func_cmd_generic(struct tee_context *ctx,
+					 struct optee_msg_arg *arg)
+{
+	struct optee_context_data *ctxdata = ctx->data;
+	struct optee_session *sess;
+	struct tee_param *params;
+	u32 key;
+	u32 func;
+
+	params = kmalloc_array(arg->num_params, sizeof(struct tee_param),
+			       GFP_KERNEL);
+	if (!params) {
+		arg->ret = TEEC_ERROR_OUT_OF_MEMORY;
+		return;
+	}
+
+	if (optee_from_msg_param(params, arg->num_params, arg->params)) {
+		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	mutex_lock(&ctxdata->mutex);
+	sess = optee_find_session(ctxdata, (u32)arg->params[0].u.value.b);
+	mutex_unlock(&ctxdata->mutex);
+	if (!sess) {
+		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+		goto out;
+	}
+
+	key = (u32)params[0].u.value.c;
+	func = (u32)params[0].u.value.a;
+	
+	arg->ret = optee_grpc_req(sess, key, func, arg->num_params, params);
+
+	if (optee_to_msg_param(arg->params, arg->num_params, params))
+		arg->ret = TEEC_ERROR_BAD_PARAMETERS;
+
+out:
+	kfree(params);
 }
 
 static void free_pages_list(struct optee_call_ctx *call_ctx)
@@ -390,6 +545,9 @@ static void handle_rpc_func_cmd(struct tee_context *ctx, struct optee *optee,
 		break;
 	case OPTEE_MSG_RPC_CMD_SHM_FREE:
 		handle_rpc_func_cmd_shm_free(ctx, arg);
+		break;
+	case OPTEE_MSG_RPC_CMD_GENERIC:
+		handle_rpc_func_cmd_generic(ctx, arg);
 		break;
 	default:
 		handle_rpc_supp_cmd(ctx, arg);

--- a/drivers/tee/optee/shm_pool.c
+++ b/drivers/tee/optee/shm_pool.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2017, EPAM Systems
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#include <linux/device.h>
+#include <linux/dma-buf.h>
+#include <linux/genalloc.h>
+#include <linux/slab.h>
+#include <linux/tee_drv.h>
+#include "optee_private.h"
+#include "optee_smc.h"
+#include "shm_pool.h"
+
+static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
+			 struct tee_shm *shm, size_t size)
+{
+	unsigned int order = get_order(size);
+	struct page *page;
+
+	page = alloc_pages(GFP_KERNEL | __GFP_ZERO, order);
+	if (!page)
+		return -ENOMEM;
+
+	shm->kaddr = page_address(page);
+	shm->paddr = page_to_phys(page);
+	shm->size = PAGE_SIZE << order;
+
+	return 0;
+}
+
+static void pool_op_free(struct tee_shm_pool_mgr *poolm,
+			 struct tee_shm *shm)
+{
+	free_pages((unsigned long)shm->kaddr, get_order(shm->size));
+	shm->kaddr = NULL;
+}
+
+static void pool_op_destroy_poolmgr(struct tee_shm_pool_mgr *poolm)
+{
+	kfree(poolm);
+}
+
+static const struct tee_shm_pool_mgr_ops pool_ops = {
+	.alloc = pool_op_alloc,
+	.free = pool_op_free,
+	.destroy_poolmgr = pool_op_destroy_poolmgr,
+};
+
+/**
+ * optee_shm_pool_alloc_pages() - create page-based allocator pool
+ *
+ * This pool is used when OP-TEE supports dymanic SHM. In this case
+ * command buffers and such are allocated from kernel's own memory.
+ */
+struct tee_shm_pool_mgr *optee_shm_pool_alloc_pages(void)
+{
+	struct tee_shm_pool_mgr *mgr = kzalloc(sizeof(*mgr), GFP_KERNEL);
+
+	if (!mgr)
+		return ERR_PTR(-ENOMEM);
+
+	mgr->ops = &pool_ops;
+
+	return mgr;
+}

--- a/drivers/tee/optee/shm_pool.h
+++ b/drivers/tee/optee/shm_pool.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015, Linaro Limited
+ * Copyright (c) 2016, EPAM Systems
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef SHM_POOL_H
+#define SHM_POOL_H
+
+#include <linux/tee_drv.h>
+
+struct tee_shm_pool_mgr *optee_shm_pool_alloc_pages(void);
+
+#endif

--- a/drivers/tee/optee/supp.c
+++ b/drivers/tee/optee/supp.c
@@ -16,21 +16,61 @@
 #include <linux/uaccess.h>
 #include "optee_private.h"
 
+struct optee_supp_req {
+	struct list_head link;
+
+	bool busy;
+	u32 func;
+	u32 ret;
+	size_t num_params;
+	struct tee_param *param;
+
+	struct completion c;
+};
+
 void optee_supp_init(struct optee_supp *supp)
 {
 	memset(supp, 0, sizeof(*supp));
-	mutex_init(&supp->ctx_mutex);
-	mutex_init(&supp->thrd_mutex);
-	mutex_init(&supp->supp_mutex);
-	init_completion(&supp->data_to_supp);
-	init_completion(&supp->data_from_supp);
+	mutex_init(&supp->mutex);
+	init_completion(&supp->reqs_c);
+	idr_init(&supp->idr);
+	INIT_LIST_HEAD(&supp->reqs);
+	supp->req_id = -1;
 }
 
 void optee_supp_uninit(struct optee_supp *supp)
 {
-	mutex_destroy(&supp->ctx_mutex);
-	mutex_destroy(&supp->thrd_mutex);
-	mutex_destroy(&supp->supp_mutex);
+	mutex_destroy(&supp->mutex);
+	idr_destroy(&supp->idr);
+}
+
+void optee_supp_release(struct optee_supp *supp)
+{
+	int id;
+	struct optee_supp_req *req;
+	struct optee_supp_req *req_tmp;
+
+	mutex_lock(&supp->mutex);
+
+	/* Abort all request retrieved by supplicant */
+	idr_for_each_entry(&supp->idr, req, id) {
+		req->busy = false;
+		idr_remove(&supp->idr, id);
+		req->ret = TEEC_ERROR_COMMUNICATION;
+		complete(&req->c);
+	}
+
+	/* Abort all queued requests */
+	list_for_each_entry_safe(req, req_tmp, &supp->reqs, link) {
+		list_del(&req->link);
+		req->ret = TEEC_ERROR_COMMUNICATION;
+		complete(&req->c);
+	}
+
+	supp->ctx = NULL;
+	supp->req_id = -1;
+
+	mutex_unlock(&supp->mutex);
 }
 
 /**
@@ -44,53 +84,42 @@ void optee_supp_uninit(struct optee_supp *supp)
  */
 u32 optee_supp_thrd_req(struct tee_context *ctx, u32 func, size_t num_params,
 			struct tee_param *param)
+
 {
-	bool interruptable;
 	struct optee *optee = tee_get_drvdata(ctx->teedev);
 	struct optee_supp *supp = &optee->supp;
+	struct optee_supp_req *req = kzalloc(sizeof(*req), GFP_KERNEL);
+	bool interruptable;
 	u32 ret;
 
-	/*
-	 * Other threads blocks here until we've copied our answer from
-	 * supplicant.
-	 */
-	while (mutex_lock_interruptible(&supp->thrd_mutex)) {
-		/* See comment below on when the RPC can be interrupted. */
-		mutex_lock(&supp->ctx_mutex);
-		interruptable = !supp->ctx;
-		mutex_unlock(&supp->ctx_mutex);
-		if (interruptable)
-			return TEEC_ERROR_COMMUNICATION;
-	}
+	if (!req)
+		return TEEC_ERROR_OUT_OF_MEMORY;
 
-	/*
-	 * We have exclusive access now since the supplicant at this
-	 * point is either doing a
-	 * wait_for_completion_interruptible(&supp->data_to_supp) or is in
-	 * userspace still about to do the ioctl() to enter
-	 * optee_supp_recv() below.
-	 */
+	init_completion(&req->c);
+	req->func = func;
+	req->num_params = num_params;
+	req->param = param;
 
-	supp->func = func;
-	supp->num_params = num_params;
-	supp->param = param;
-	supp->req_posted = true;
+	/* Insert the request in the request list */
+	mutex_lock(&supp->mutex);
+	list_add_tail(&req->link, &supp->reqs);
+	mutex_unlock(&supp->mutex);
 
-	/* Let supplicant get the data */
-	complete(&supp->data_to_supp);
+	/* Tell an eventual waiter there's a new request */
+	complete(&supp->reqs_c);
 
 	/*
 	 * Wait for supplicant to process and return result, once we've
-	 * returned from wait_for_completion(data_from_supp) we have
+	 * returned from wait_for_completion(&req->c) successfully we have
 	 * exclusive access again.
 	 */
-	while (wait_for_completion_interruptible(&supp->data_from_supp)) {
-		mutex_lock(&supp->ctx_mutex);
+	while (wait_for_completion_interruptible(&req->c)) {
+		mutex_lock(&supp->mutex);
 		interruptable = !supp->ctx;
 		if (interruptable) {
 			/*
 			 * There's no supplicant available and since the
-			 * supp->ctx_mutex currently is held none can
+			 * supp->mutex currently is held none can
 			 * become available until the mutex released
 			 * again.
 			 *
@@ -101,27 +130,64 @@ u32 optee_supp_thrd_req(struct tee_context *ctx, u32 func, size_t num_params,
 			 * will serve all requests in a timely manner and
 			 * interrupting then wouldn't make sense.
 			 */
-			supp->ret = TEEC_ERROR_COMMUNICATION;
-			init_completion(&supp->data_to_supp);
+			interruptable = !req->busy;
+			if (!req->busy)
+				list_del(&req->link);
 		}
-		mutex_unlock(&supp->ctx_mutex);
-		if (interruptable)
+		mutex_unlock(&supp->mutex);
+
+		if (interruptable) {
+			req->ret = TEEC_ERROR_COMMUNICATION;
 			break;
+		}
 	}
 
-	ret = supp->ret;
-	supp->param = NULL;
-	supp->req_posted = false;
-
-	/* We're done, let someone else talk to the supplicant now. */
-	mutex_unlock(&supp->thrd_mutex);
+	ret = req->ret;
+	kfree(req);
 
 	return ret;
 }
 
-static int supp_check_recv_params(size_t num_params, struct tee_param *params)
+static struct optee_supp_req  *supp_pop_entry(struct optee_supp *supp,
+					      int num_params, int *id)
+{
+	struct optee_supp_req *req;
+
+	if (supp->req_id != -1) {
+		/*
+		 * Supplicant should not mix synchronous and asnynchronous
+		 * requests.
+		 */
+		return ERR_PTR(-EINVAL);
+	}
+
+	if (list_empty(&supp->reqs))
+		return NULL;
+
+	req = list_first_entry(&supp->reqs, struct optee_supp_req, link);
+
+	if (num_params < req->num_params) {
+		/* Not enough room for parameters */
+		return ERR_PTR(-EINVAL);
+	}
+
+	*id = idr_alloc(&supp->idr, req, 1, 0, GFP_KERNEL);
+	if (*id < 0)
+		return ERR_PTR(-ENOMEM);
+
+	list_del(&req->link);
+	req->busy = true;
+
+	return req;
+}
+
+static int supp_check_recv_params(size_t num_params, struct tee_param *params,
+				  size_t *num_meta)
 {
 	size_t n;
+
+	if (!num_params)
+		return -EINVAL;
 
 	/*
 	 * If there's memrefs we need to decrease those as they where
@@ -132,11 +198,20 @@ static int supp_check_recv_params(size_t num_params, struct tee_param *params)
 			tee_shm_put(params[n].u.memref.shm);
 
 	/*
-	 * We only expect parameters as TEE_IOCTL_PARAM_ATTR_TYPE_NONE (0).
+	 * We only expect parameters as TEE_IOCTL_PARAM_ATTR_TYPE_NONE with
+	 * or without the TEE_IOCTL_PARAM_ATTR_META bit set.
 	 */
 	for (n = 0; n < num_params; n++)
-		if (params[n].attr)
+		if (params[n].attr &&
+		    params[n].attr != TEE_IOCTL_PARAM_ATTR_META)
 			return -EINVAL;
+
+	/* At most we'll need one meta parameter so no need to check for more */
+	if (params->attr == TEE_IOCTL_PARAM_ATTR_META)
+		*num_meta = 1;
+	else
+		*num_meta = 0;
+
 	return 0;
 }
 
@@ -156,69 +231,99 @@ int optee_supp_recv(struct tee_context *ctx, u32 *func, u32 *num_params,
 	struct tee_device *teedev = ctx->teedev;
 	struct optee *optee = tee_get_drvdata(teedev);
 	struct optee_supp *supp = &optee->supp;
+	struct optee_supp_req *req = NULL;
+	int id;
+	size_t num_meta;
 	int rc;
 
-	rc = supp_check_recv_params(*num_params, param);
+	rc = supp_check_recv_params(*num_params, param, &num_meta);
 	if (rc)
 		return rc;
 
-	/*
-	 * In case two threads in one supplicant is calling this function
-	 * simultaneously we need to protect the data with a mutex which
-	 * we'll release before returning.
-	 */
-	mutex_lock(&supp->supp_mutex);
+	while (true) {
+		mutex_lock(&supp->mutex);
+		req = supp_pop_entry(supp, *num_params - num_meta, &id);
+		mutex_unlock(&supp->mutex);
 
-	if (supp->supp_next_send) {
-		/*
-		 * optee_supp_recv() has been called again without
-		 * a optee_supp_send() in between. Supplicant has
-		 * probably been restarted before it was able to
-		 * write back last result. Abort last request and
-		 * wait for a new.
-		 */
-		if (supp->req_posted) {
-			supp->ret = TEEC_ERROR_COMMUNICATION;
-			supp->supp_next_send = false;
-			complete(&supp->data_from_supp);
+		if (req) {
+			if (IS_ERR(req))
+				return PTR_ERR(req);
+			break;
 		}
-	}
 
-	/*
-	 * This is where supplicant will be hanging most of the
-	 * time, let's make this interruptable so we can easily
-	 * restart supplicant if needed.
-	 */
-	if (wait_for_completion_interruptible(&supp->data_to_supp)) {
-		rc = -ERESTARTSYS;
-		goto out;
-	}
-
-	/* We have exlusive access to the data */
-
-	if (*num_params < supp->num_params) {
 		/*
-		 * Not enough room for parameters, tell supplicant
-		 * it failed and abort last request.
+		 * If we didn't get a request we'll block in
+		 * wait_for_completion() to avoid needless spinning.
+		 *
+		 * This is where supplicant will be hanging most of
+		 * the time, let's make this interruptable so we
+		 * can easily restart supplicant if needed.
 		 */
-		supp->ret = TEEC_ERROR_COMMUNICATION;
-		rc = -EINVAL;
-		complete(&supp->data_from_supp);
-		goto out;
+		if (wait_for_completion_interruptible(&supp->reqs_c))
+			return -ERESTARTSYS;
 	}
 
-	*func = supp->func;
-	*num_params = supp->num_params;
-	memcpy(param, supp->param,
-	       sizeof(struct tee_param) * supp->num_params);
+	if (num_meta) {
+		/*
+		 * tee-supplicant support meta parameters -> requsts can be
+		 * processed asynchronously.
+		 */
+		param->attr = TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT |
+			      TEE_IOCTL_PARAM_ATTR_META;
+		param->u.value.a = id;
+		param->u.value.b = 0;
+		param->u.value.c = 0;
+	} else {
+		mutex_lock(&supp->mutex);
+		supp->req_id = id;
+		mutex_unlock(&supp->mutex);
+	}
 
-	/* Allow optee_supp_send() below to do its work */
-	supp->supp_next_send = true;
+	*func = req->func;
+	*num_params = req->num_params + num_meta;
+	memcpy(param + num_meta, req->param,
+	       sizeof(struct tee_param) * req->num_params);
 
-	rc = 0;
-out:
-	mutex_unlock(&supp->supp_mutex);
-	return rc;
+	return 0;
+}
+
+static struct optee_supp_req *supp_pop_req(struct optee_supp *supp,
+					   size_t num_params,
+					   struct tee_param *param,
+					   size_t *num_meta)
+{
+	struct optee_supp_req *req;
+	int id;
+	size_t nm;
+	const u32 attr = TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT |
+			 TEE_IOCTL_PARAM_ATTR_META;
+
+	if (!num_params)
+		return ERR_PTR(-EINVAL);
+
+	if (supp->req_id == -1) {
+		if (param->attr != attr)
+			return ERR_PTR(-EINVAL);
+		id = param->u.value.a;
+		nm = 1;
+	} else {
+		id = supp->req_id;
+		nm = 0;
+	}
+
+	req = idr_find(&supp->idr, id);
+	if (!req)
+		return ERR_PTR(-ENOENT);
+
+	if ((num_params - nm) != req->num_params)
+		return ERR_PTR(-EINVAL);
+
+	req->busy = false;
+	idr_remove(&supp->idr, id);
+	supp->req_id = -1;
+	*num_meta = nm;
+
+	return req;
 }
 
 /**
@@ -236,63 +341,42 @@ int optee_supp_send(struct tee_context *ctx, u32 ret, u32 num_params,
 	struct tee_device *teedev = ctx->teedev;
 	struct optee *optee = tee_get_drvdata(teedev);
 	struct optee_supp *supp = &optee->supp;
+	struct optee_supp_req *req;
 	size_t n;
-	int rc = 0;
+	size_t num_meta;
 
-	/*
-	 * We still have exclusive access to the data since that's how we
-	 * left it when returning from optee_supp_read().
-	 */
+	mutex_lock(&supp->mutex);
+	req = supp_pop_req(supp, num_params, param, &num_meta);
+	mutex_unlock(&supp->mutex);
 
-	/* See comment on mutex in optee_supp_read() above */
-	mutex_lock(&supp->supp_mutex);
-
-	if (!supp->supp_next_send) {
-		/*
-		 * Something strange is going on, supplicant shouldn't
-		 * enter optee_supp_send() in this state
-		 */
-		rc = -ENOENT;
-		goto out;
-	}
-
-	if (num_params != supp->num_params) {
-		/*
-		 * Something is wrong, let supplicant restart. Next call to
-		 * optee_supp_recv() will give an error to the requesting
-		 * thread and release it.
-		 */
-		rc = -EINVAL;
-		goto out;
+	if (IS_ERR(req)) {
+		/* Something is wrong, let supplicant restart. */
+		return PTR_ERR(req);
 	}
 
 	/* Update out and in/out parameters */
-	for (n = 0; n < num_params; n++) {
-		struct tee_param *p = supp->param + n;
+	for (n = 0; n < req->num_params; n++) {
+		struct tee_param *p = req->param + n;
 
-		switch (p->attr) {
+		switch (p->attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) {
 		case TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_OUTPUT:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT:
-			p->u.value.a = param[n].u.value.a;
-			p->u.value.b = param[n].u.value.b;
-			p->u.value.c = param[n].u.value.c;
+			p->u.value.a = param[n + num_meta].u.value.a;
+			p->u.value.b = param[n + num_meta].u.value.b;
+			p->u.value.c = param[n + num_meta].u.value.c;
 			break;
 		case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT:
-			p->u.memref.size = param[n].u.memref.size;
+			p->u.memref.size = param[n + num_meta].u.memref.size;
 			break;
 		default:
 			break;
 		}
 	}
-	supp->ret = ret;
-
-	/* Allow optee_supp_recv() above to do its work */
-	supp->supp_next_send = false;
+	req->ret = ret;
 
 	/* Let the requesting thread continue */
-	complete(&supp->data_from_supp);
-out:
-	mutex_unlock(&supp->supp_mutex);
-	return rc;
+	complete(&req->c);
+
+	return 0;
 }

--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -255,11 +255,11 @@ static int params_from_user(struct tee_context *ctx, struct tee_param *params,
 			return -EFAULT;
 
 		/* All unused attribute bits has to be zero */
-		if (ip.attr & ~TEE_IOCTL_PARAM_ATTR_TYPE_MASK)
+		if (ip.attr & ~TEE_IOCTL_PARAM_ATTR_MASK)
 			return -EINVAL;
 
 		params[n].attr = ip.attr;
-		switch (ip.attr) {
+		switch (ip.attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) {
 		case TEE_IOCTL_PARAM_ATTR_TYPE_NONE:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_OUTPUT:
 			break;
@@ -508,8 +508,8 @@ static int params_to_supp(struct tee_context *ctx,
 		struct tee_ioctl_param ip;
 		struct tee_param *p = params + n;
 
-		ip.attr = p->attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK;
-		switch (p->attr) {
+		ip.attr = p->attr;
+		switch (p->attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) {
 		case TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INPUT:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT:
 			ip.a = p->u.value.a;
@@ -573,6 +573,10 @@ static int tee_ioctl_supp_recv(struct tee_context *ctx,
 	if (!params)
 		return -ENOMEM;
 
+	rc = params_from_user(ctx, params, num_params, uarg->params);
+	if (rc)
+		goto out;
+
 	rc = ctx->teedev->desc->ops->supp_recv(ctx, &func, &num_params, params);
 	if (rc)
 		goto out;
@@ -602,11 +606,11 @@ static int params_from_supp(struct tee_param *params, size_t num_params,
 			return -EFAULT;
 
 		/* All unused attribute bits has to be zero */
-		if (ip.attr & ~TEE_IOCTL_PARAM_ATTR_TYPE_MASK)
+		if (ip.attr & ~TEE_IOCTL_PARAM_ATTR_MASK)
 			return -EINVAL;
 
 		p->attr = ip.attr;
-		switch (ip.attr) {
+		switch (ip.attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) {
 		case TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_OUTPUT:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_VALUE_INOUT:
 			/* Only out and in/out values can be updated */

--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -681,6 +681,122 @@ out:
 	kfree(params);
 	return rc;
 }
+int tee_ioctl_grpc_recv(struct tee_context *ctx,
+			       struct tee_ioctl_buf_data __user *ubuf);
+ noinline int tee_ioctl_grpc_recv(struct tee_context *ctx,
+			       struct tee_ioctl_buf_data __user *ubuf)
+{
+	int rc;
+	struct tee_ioctl_buf_data buf;
+	struct tee_ioctl_grpc_recv_arg __user *uarg;
+	struct tee_param *params;
+	u32 session;
+	u32 key;
+	u32 func;
+	u32 num_params;
+
+	if (!ctx->teedev->desc->ops->grpc_recv)
+		return -EINVAL;
+
+	if (copy_from_user(&buf, ubuf, sizeof(buf)))
+		return -EFAULT;
+	
+	if (buf.buf_len > TEE_MAX_ARG_SIZE ||
+		buf.buf_len < sizeof(struct tee_ioctl_grpc_recv_arg))
+		return -EINVAL;
+	
+	uarg = u64_to_user_ptr(buf.buf_ptr);
+	if (get_user(num_params, &uarg->num_params) ||
+		get_user(session, &uarg->session))
+		return -EFAULT;
+	
+	if (sizeof(*uarg) + TEE_IOCTL_PARAM_SIZE(num_params) != buf.buf_len)
+		return -EINVAL;
+	
+	params = kcalloc(num_params, sizeof(struct tee_param), GFP_KERNEL);
+	if (!params)
+		return -ENOMEM;
+	
+	rc = params_from_user(ctx, params, num_params, uarg->params);
+	if (rc)
+		goto out;
+
+	rc = ctx->teedev->desc->ops->grpc_recv(ctx, session, &key, &func, num_params, params);
+	if (rc)
+		goto out;
+	
+	if (put_user(key, &uarg->key) ||
+		put_user(func, &uarg->func)) {
+		rc = -EFAULT;
+		goto out;
+	}
+
+	rc = params_to_supp(ctx, uarg->params, num_params, params);
+out:
+	kfree(params);
+	return rc;
+}
+
+static int tee_ioctl_grpc_send(struct tee_context *ctx,
+			       struct tee_ioctl_buf_data __user *ubuf)
+{
+	int rc;
+	size_t n;
+	struct tee_ioctl_buf_data buf;
+	struct tee_ioctl_grpc_send_arg __user *uarg;
+	struct tee_ioctl_grpc_send_arg arg;
+	struct tee_ioctl_param __user *uparams = NULL;
+	struct tee_param *params = NULL;
+
+	if (!ctx->teedev->desc->ops->grpc_recv)
+		return -EINVAL;
+
+	if (copy_from_user(&buf, ubuf, sizeof(buf)))
+		return -EFAULT;
+	
+	if (buf.buf_len > TEE_MAX_ARG_SIZE ||
+		buf.buf_len < sizeof(struct tee_ioctl_grpc_send_arg))
+		return -EINVAL;
+	
+	uarg = u64_to_user_ptr(buf.buf_ptr);
+	if (copy_from_user(&arg, uarg, sizeof(arg)))
+		return -EFAULT;
+	
+	if (sizeof(arg) + TEE_IOCTL_PARAM_SIZE(arg.num_params) != buf.buf_len)
+		return -EINVAL;
+	
+	if (arg.num_params) {
+		params = kcalloc(arg.num_params, sizeof(struct tee_param),
+						 GFP_KERNEL);
+		if (!params)
+			return -ENOMEM;
+		uparams = uarg->params;
+		rc = params_from_user(ctx, params, arg.num_params, uparams);
+		if (rc)
+			goto out;
+	}
+
+	rc = ctx->teedev->desc->ops->grpc_send(ctx, &arg, params);
+	if (rc)
+		goto out;
+	
+	if (put_user(arg.ret, &uarg->ret)) {
+		rc = -EFAULT;
+		goto out;
+	}
+	rc = params_to_user(uparams, arg.num_params, params);
+
+out:
+	if (params) {
+		/* Decrease ref count for all valid shared memory pointers */
+		for (n = 0; n < arg.num_params; n++)
+			if (tee_param_is_memref(params + n) &&
+			    params[n].u.memref.shm)
+				tee_shm_put(params[n].u.memref.shm);
+		kfree(params);
+	}
+	return rc;
+}
 
 static long tee_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
@@ -708,6 +824,10 @@ static long tee_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		return tee_ioctl_supp_recv(ctx, uarg);
 	case TEE_IOC_SUPPL_SEND:
 		return tee_ioctl_supp_send(ctx, uarg);
+	case TEE_IOC_GRPC_RECV:
+		return tee_ioctl_grpc_recv(ctx, uarg);
+	case TEE_IOC_GRPC_SEND:
+		return tee_ioctl_grpc_send(ctx, uarg);
 	default:
 		return -EINVAL;
 	}

--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -335,18 +335,6 @@ static int params_to_user(struct tee_ioctl_param __user *uparams,
 	return 0;
 }
 
-static bool param_is_memref(struct tee_param *param)
-{
-	switch (param->attr & TEE_IOCTL_PARAM_ATTR_TYPE_MASK) {
-	case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INPUT:
-	case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_OUTPUT:
-	case TEE_IOCTL_PARAM_ATTR_TYPE_MEMREF_INOUT:
-		return true;
-	default:
-		return false;
-	}
-}
-
 static int tee_ioctl_open_session(struct tee_context *ctx,
 				  struct tee_ioctl_buf_data __user *ubuf)
 {
@@ -410,7 +398,7 @@ out:
 	if (params) {
 		/* Decrease ref count for all valid shared memory pointers */
 		for (n = 0; n < arg.num_params; n++)
-			if (param_is_memref(params + n) &&
+			if (tee_param_is_memref(params + n) &&
 			    params[n].u.memref.shm)
 				tee_shm_put(params[n].u.memref.shm);
 		kfree(params);
@@ -472,7 +460,7 @@ out:
 	if (params) {
 		/* Decrease ref count for all valid shared memory pointers */
 		for (n = 0; n < arg.num_params; n++)
-			if (param_is_memref(params + n) &&
+			if (tee_param_is_memref(params + n) &&
 			    params[n].u.memref.shm)
 				tee_shm_put(params[n].u.memref.shm);
 		kfree(params);

--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -682,16 +682,14 @@ out:
 	return rc;
 }
 
-int tee_ioctl_grpc_recv(struct tee_context *ctx, struct tee_ioctl_buf_data __user *ubuf);
-noinline int tee_ioctl_grpc_recv(struct tee_context *ctx,
-			       struct tee_ioctl_buf_data __user *ubuf)
+int tee_ioctl_grpc_recv(struct tee_context *ctx,
+			struct tee_ioctl_buf_data __user *ubuf)
 {
 	int rc;
 	struct tee_ioctl_buf_data buf;
 	struct tee_ioctl_grpc_recv_arg __user *uarg;
 	struct tee_param *params;
 	u32 session;
-	u32 key;
 	u32 func;
 	u32 num_params;
 
@@ -721,12 +719,11 @@ noinline int tee_ioctl_grpc_recv(struct tee_context *ctx,
 	if (rc)
 		goto out;
 
-	rc = ctx->teedev->desc->ops->grpc_recv(ctx, session, &key, &func, &num_params, params);
+	rc = ctx->teedev->desc->ops->grpc_recv(ctx, session, &func, &num_params, params);
 	if (rc)
 		goto out;
 	
-	if (put_user(key, &uarg->key) ||
-	    put_user(func, &uarg->func) ||
+	if (put_user(func, &uarg->func) ||
 	    put_user(num_params, &uarg->num_params)) {
 		rc = -EFAULT;
 		goto out;
@@ -738,8 +735,7 @@ out:
 	return rc;
 }
 
-int tee_ioctl_grpc_send(struct tee_context *ctx, struct tee_ioctl_buf_data __user *ubuf);
-noinline int tee_ioctl_grpc_send(struct tee_context *ctx,
+int tee_ioctl_grpc_send(struct tee_context *ctx,
 			       struct tee_ioctl_buf_data __user *ubuf)
 {
 	int rc;
@@ -748,7 +744,6 @@ noinline int tee_ioctl_grpc_send(struct tee_context *ctx,
 	struct tee_ioctl_param __user *uparams = NULL;
 	struct tee_param *params = NULL;
 	u32 session;
-	u32 key;
 	u32 ret;
 	u32 num_params;
 	
@@ -764,7 +759,6 @@ noinline int tee_ioctl_grpc_send(struct tee_context *ctx,
 	
 	uarg = u64_to_user_ptr(buf.buf_ptr);
 	if (get_user(session, &uarg->session) ||
-	    get_user(key, &uarg->key) ||
 	    get_user(ret, &uarg->ret) ||
 	    get_user(num_params, &uarg->num_params))
 		return -EFAULT;	
@@ -781,7 +775,7 @@ noinline int tee_ioctl_grpc_send(struct tee_context *ctx,
 	if (rc)
 		goto out;
 
-	rc = ctx->teedev->desc->ops->grpc_send(ctx, session, key, ret, num_params, params);
+	rc = ctx->teedev->desc->ops->grpc_send(ctx, session, ret, num_params, params);
 out:
 	kfree(params);
 	return rc;

--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -681,9 +681,9 @@ out:
 	kfree(params);
 	return rc;
 }
-int tee_ioctl_grpc_recv(struct tee_context *ctx,
-			       struct tee_ioctl_buf_data __user *ubuf);
- noinline int tee_ioctl_grpc_recv(struct tee_context *ctx,
+
+int tee_ioctl_grpc_recv(struct tee_context *ctx, struct tee_ioctl_buf_data __user *ubuf);
+noinline int tee_ioctl_grpc_recv(struct tee_context *ctx,
 			       struct tee_ioctl_buf_data __user *ubuf)
 {
 	int rc;
@@ -721,12 +721,13 @@ int tee_ioctl_grpc_recv(struct tee_context *ctx,
 	if (rc)
 		goto out;
 
-	rc = ctx->teedev->desc->ops->grpc_recv(ctx, session, &key, &func, num_params, params);
+	rc = ctx->teedev->desc->ops->grpc_recv(ctx, session, &key, &func, &num_params, params);
 	if (rc)
 		goto out;
 	
 	if (put_user(key, &uarg->key) ||
-		put_user(func, &uarg->func)) {
+	    put_user(func, &uarg->func) ||
+	    put_user(num_params, &uarg->num_params)) {
 		rc = -EFAULT;
 		goto out;
 	}
@@ -737,17 +738,20 @@ out:
 	return rc;
 }
 
-static int tee_ioctl_grpc_send(struct tee_context *ctx,
+int tee_ioctl_grpc_send(struct tee_context *ctx, struct tee_ioctl_buf_data __user *ubuf);
+noinline int tee_ioctl_grpc_send(struct tee_context *ctx,
 			       struct tee_ioctl_buf_data __user *ubuf)
 {
 	int rc;
-	size_t n;
 	struct tee_ioctl_buf_data buf;
 	struct tee_ioctl_grpc_send_arg __user *uarg;
-	struct tee_ioctl_grpc_send_arg arg;
 	struct tee_ioctl_param __user *uparams = NULL;
 	struct tee_param *params = NULL;
-
+	u32 session;
+	u32 key;
+	u32 ret;
+	u32 num_params;
+	
 	if (!ctx->teedev->desc->ops->grpc_recv)
 		return -EINVAL;
 
@@ -759,42 +763,27 @@ static int tee_ioctl_grpc_send(struct tee_context *ctx,
 		return -EINVAL;
 	
 	uarg = u64_to_user_ptr(buf.buf_ptr);
-	if (copy_from_user(&arg, uarg, sizeof(arg)))
-		return -EFAULT;
+	if (get_user(session, &uarg->session) ||
+	    get_user(key, &uarg->key) ||
+	    get_user(ret, &uarg->ret) ||
+	    get_user(num_params, &uarg->num_params))
+		return -EFAULT;	
 	
-	if (sizeof(arg) + TEE_IOCTL_PARAM_SIZE(arg.num_params) != buf.buf_len)
+	if (sizeof(*uarg) + TEE_IOCTL_PARAM_SIZE(num_params) != buf.buf_len)
 		return -EINVAL;
 	
-	if (arg.num_params) {
-		params = kcalloc(arg.num_params, sizeof(struct tee_param),
-						 GFP_KERNEL);
-		if (!params)
-			return -ENOMEM;
-		uparams = uarg->params;
-		rc = params_from_user(ctx, params, arg.num_params, uparams);
-		if (rc)
-			goto out;
-	}
+	params = kcalloc(num_params, sizeof(struct tee_param), GFP_KERNEL);
+	if (!params)
+		return -ENOMEM;
 
-	rc = ctx->teedev->desc->ops->grpc_send(ctx, &arg, params);
+	uparams = uarg->params;
+	rc = params_from_supp(params, num_params, uarg->params);
 	if (rc)
 		goto out;
-	
-	if (put_user(arg.ret, &uarg->ret)) {
-		rc = -EFAULT;
-		goto out;
-	}
-	rc = params_to_user(uparams, arg.num_params, params);
 
+	rc = ctx->teedev->desc->ops->grpc_send(ctx, session, key, ret, num_params, params);
 out:
-	if (params) {
-		/* Decrease ref count for all valid shared memory pointers */
-		for (n = 0; n < arg.num_params; n++)
-			if (tee_param_is_memref(params + n) &&
-			    params[n].u.memref.shm)
-				tee_shm_put(params[n].u.memref.shm);
-		kfree(params);
-	}
+	kfree(params);
 	return rc;
 }
 

--- a/drivers/tee/tee_core.c
+++ b/drivers/tee/tee_core.c
@@ -752,7 +752,7 @@ struct tee_device *tee_device_alloc(const struct tee_desc *teedesc,
 {
 	struct tee_device *teedev;
 	void *ret;
-	int rc;
+	int rc, max_id;
 	int offs = 0;
 
 	if (!teedesc || !teedesc->name || !teedesc->ops ||
@@ -766,16 +766,20 @@ struct tee_device *tee_device_alloc(const struct tee_desc *teedesc,
 		goto err;
 	}
 
-	if (teedesc->flags & TEE_DESC_PRIVILEGED)
+	max_id = TEE_NUM_DEVICES / 2;
+
+	if (teedesc->flags & TEE_DESC_PRIVILEGED) {
 		offs = TEE_NUM_DEVICES / 2;
+		max_id = TEE_NUM_DEVICES;
+	}
 
 	spin_lock(&driver_lock);
-	teedev->id = find_next_zero_bit(dev_mask, TEE_NUM_DEVICES, offs);
-	if (teedev->id < TEE_NUM_DEVICES)
+	teedev->id = find_next_zero_bit(dev_mask, max_id, offs);
+	if (teedev->id < max_id)
 		set_bit(teedev->id, dev_mask);
 	spin_unlock(&driver_lock);
 
-	if (teedev->id >= TEE_NUM_DEVICES) {
+	if (teedev->id >= max_id) {
 		ret = ERR_PTR(-ENOMEM);
 		goto err;
 	}

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -314,7 +314,7 @@ struct tee_shm *tee_shm_register(struct tee_context *ctx, unsigned long addr,
 	}
 
 	rc = teedev->desc->ops->shm_register(ctx, shm, shm->pages,
-					     shm->num_pages);
+					     shm->num_pages, start);
 	if (rc) {
 		ret = ERR_PTR(rc);
 		goto err;

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -127,9 +127,9 @@ static const struct dma_buf_ops tee_shm_dma_buf_ops = {
 	.mmap = tee_shm_op_mmap,
 };
 
-struct tee_shm *__tee_shm_alloc(struct tee_context *ctx,
-				struct tee_device *teedev,
-				size_t size, u32 flags)
+static struct tee_shm *__tee_shm_alloc(struct tee_context *ctx,
+				       struct tee_device *teedev,
+				       size_t size, u32 flags)
 {
 	struct tee_shm_pool_mgr *poolm = NULL;
 	struct tee_shm *shm;

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -607,17 +607,6 @@ struct tee_shm *tee_shm_get_from_id(struct tee_context *ctx, int id)
 EXPORT_SYMBOL_GPL(tee_shm_get_from_id);
 
 /**
- * tee_shm_get_id() - Get id of a shared memory object
- * @shm:	Shared memory handle
- * @returns id
- */
-int tee_shm_get_id(struct tee_shm *shm)
-{
-	return shm->id;
-}
-EXPORT_SYMBOL_GPL(tee_shm_get_id);
-
-/**
  * tee_shm_put() - Decrease reference count on a shared memory handle
  * @shm:	Shared memory handle
  */

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -298,7 +298,7 @@ struct tee_shm *tee_shm_register(struct tee_context *ctx, unsigned long addr,
 	if (rc > 0)
 		shm->num_pages = rc;
 	if (rc != num_pages) {
-		if (rc > 0)
+		if (rc >= 0)
 			rc = -ENOMEM;
 		ret = ERR_PTR(rc);
 		goto err;

--- a/drivers/tee/tee_shm.c
+++ b/drivers/tee/tee_shm.c
@@ -350,9 +350,11 @@ err:
 			idr_remove(&teedev->idr, shm->id);
 			mutex_unlock(&teedev->mutex);
 		}
-		for (n = 0; n < shm->num_pages; n++)
-			put_page(shm->pages[n]);
-		kfree(shm->pages);
+		if (shm->pages) {
+			for (n = 0; n < shm->num_pages; n++)
+				put_page(shm->pages[n]);
+			kfree(shm->pages);
+		}
 	}
 	kfree(shm);
 	teedev_ctx_put(ctx);

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -108,7 +108,8 @@ struct tee_driver_ops {
 	int (*supp_send)(struct tee_context *ctx, u32 ret, u32 num_params,
 			 struct tee_param *param);
 	int (*shm_register)(struct tee_context *ctx, struct tee_shm *shm,
-			    struct page **pages, size_t num_pages);
+			    struct page **pages, size_t num_pages,
+			    unsigned long start);
 	int (*shm_unregister)(struct tee_context *ctx, struct tee_shm *shm);
 };
 

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -109,9 +109,9 @@ struct tee_driver_ops {
 			 struct tee_param *param);
 	int (*supp_send)(struct tee_context *ctx, u32 ret, u32 num_params,
 			 struct tee_param *param);
-	int (*grpc_recv)(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 *num_params,
-				struct tee_param *param);
-	int (*grpc_send)(struct tee_context *ctx, u32 session, u32 key, u32 ret, u32 num_params,
+	int (*grpc_recv)(struct tee_context *ctx, u32 session, u32 *func, u32 *num_params,
+			 struct tee_param *param);
+	int (*grpc_send)(struct tee_context *ctx, u32 session, u32 ret, u32 num_params,
 		    struct tee_param *param);
 	int (*shm_register)(struct tee_context *ctx, struct tee_shm *shm,
 			    struct page **pages, size_t num_pages,

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -109,11 +109,10 @@ struct tee_driver_ops {
 			 struct tee_param *param);
 	int (*supp_send)(struct tee_context *ctx, u32 ret, u32 num_params,
 			 struct tee_param *param);
-	int (*grpc_recv)(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 num_params,
+	int (*grpc_recv)(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 *num_params,
 				struct tee_param *param);
-	int (*grpc_send)(struct tee_context *ctx,
-				struct tee_ioctl_grpc_send_arg *arg,
-				struct tee_param *param);
+	int (*grpc_send)(struct tee_context *ctx, u32 session, u32 key, u32 ret, u32 num_params,
+		    struct tee_param *param);
 	int (*shm_register)(struct tee_context *ctx, struct tee_shm *shm,
 			    struct page **pages, size_t num_pages,
 			    unsigned long start);

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -87,6 +87,8 @@ struct tee_param {
  * @cancel_req:		request cancel of an ongoing invoke or open
  * @supp_revc:		called for supplicant to get a command
  * @supp_send:		called for supplicant to send a response
+ * @grpc_revc:		called for a host application to get a command
+ * @grpc_send:		called for a host application to send a response
  * @shm_register:	register shared memory buffer in TEE
  * @shm_unregister:	unregister shared memory buffer in TEE
  */
@@ -107,6 +109,11 @@ struct tee_driver_ops {
 			 struct tee_param *param);
 	int (*supp_send)(struct tee_context *ctx, u32 ret, u32 num_params,
 			 struct tee_param *param);
+	int (*grpc_recv)(struct tee_context *ctx, u32 session, u32 *key, u32 *func, u32 num_params,
+				struct tee_param *param);
+	int (*grpc_send)(struct tee_context *ctx,
+				struct tee_ioctl_grpc_send_arg *arg,
+				struct tee_param *param);
 	int (*shm_register)(struct tee_context *ctx, struct tee_shm *shm,
 			    struct page **pages, size_t num_pages,
 			    unsigned long start);

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -411,6 +411,26 @@ void *tee_shm_get_va(struct tee_shm *shm, size_t offs);
 int tee_shm_get_pa(struct tee_shm *shm, size_t offs, phys_addr_t *pa);
 
 /**
+ * tee_shm_get_size() - Get size of shared memory buffer
+ * @shm:	Shared memory handle
+ * @returns size of shared memory
+ */
+static inline size_t tee_shm_get_size(struct tee_shm *shm)
+{
+	return shm->size;
+}
+
+/**
+ * tee_shm_get_page_offset() - Get shared buffer offset from page start
+ * @shm:	Shared memory handle
+ * @returns page offset of shared buffer
+ */
+static inline size_t tee_shm_get_page_offset(struct tee_shm *shm)
+{
+	return shm->offset;
+}
+
+/**
  * tee_shm_get_id() - Get id of a shared memory object
  * @shm:	Shared memory handle
  * @returns id

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -448,7 +448,10 @@ static inline size_t tee_shm_get_page_offset(struct tee_shm *shm)
  * @shm:	Shared memory handle
  * @returns id
  */
-int tee_shm_get_id(struct tee_shm *shm);
+static inline int tee_shm_get_id(struct tee_shm *shm)
+{
+	return shm->id;
+}
 
 /**
  * tee_shm_get_from_id() - Find shared memory object and increase reference

--- a/include/linux/tee_drv.h
+++ b/include/linux/tee_drv.h
@@ -421,6 +421,19 @@ static inline size_t tee_shm_get_size(struct tee_shm *shm)
 }
 
 /**
+ * tee_shm_get_pages() - Get list of pages that hold shared buffer
+ * @shm:	Shared memory handle
+ * @num_pages:	Number of pages will be stored there
+ * @returns pointer to pages array
+ */
+static inline struct page **tee_shm_get_pages(struct tee_shm *shm,
+					      size_t *num_pages)
+{
+	*num_pages = shm->num_pages;
+	return shm->pages;
+}
+
+/**
  * tee_shm_get_page_offset() - Get shared buffer offset from page start
  * @shm:	Shared memory handle
  * @returns page offset of shared buffer

--- a/include/uapi/linux/tee.h
+++ b/include/uapi/linux/tee.h
@@ -409,11 +409,10 @@ struct tee_ioctl_shm_register_data {
  * host application receives when output.
  */
 struct tee_ioctl_grpc_recv_arg {
-	__u32 key;
 	__u32 func;
 	__u32 session;
+	__u32 key;
 	__u32 num_params;
-	__u32 ret;
 	
 	/* num_params tells the actual number of element in params */
 	struct tee_ioctl_param params[];
@@ -434,8 +433,9 @@ struct tee_ioctl_grpc_recv_arg {
  * @num_params	[in] number of parameters following this struct
  */
 struct tee_ioctl_grpc_send_arg {
-	__u32 session;
 	__u32 ret;
+	__u32 session;
+	__u32 key;
 	__u32 num_params;
 
 	/* num_params tells the actual number of element in params */

--- a/include/uapi/linux/tee.h
+++ b/include/uapi/linux/tee.h
@@ -402,6 +402,7 @@ struct tee_ioctl_shm_register_data {
 /**
  * struct tee_ioctl_grpc_recv_arg - Receive a request for a generic RPC function
  * @func:	[in] generic RPC function
+ * @session:	[in] session ID
  * @num_params	[in/out] number of parameters following this struct
  *
  * @num_params is the number of params that host application has room to
@@ -411,7 +412,6 @@ struct tee_ioctl_shm_register_data {
 struct tee_ioctl_grpc_recv_arg {
 	__u32 func;
 	__u32 session;
-	__u32 key;
 	__u32 num_params;
 	
 	/* num_params tells the actual number of element in params */
@@ -430,12 +430,12 @@ struct tee_ioctl_grpc_recv_arg {
 /**
  * struct tee_ioctl_grpc_send_arg - Send a response to a received request
  * @ret:	[out] return value
+ * @session:	[in] session ID
  * @num_params	[in] number of parameters following this struct
  */
 struct tee_ioctl_grpc_send_arg {
 	__u32 ret;
 	__u32 session;
-	__u32 key;
 	__u32 num_params;
 
 	/* num_params tells the actual number of element in params */

--- a/include/uapi/linux/tee.h
+++ b/include/uapi/linux/tee.h
@@ -398,6 +398,59 @@ struct tee_ioctl_shm_register_data {
  */
 #define TEE_IOC_SHM_REGISTER   _IOWR(TEE_IOC_MAGIC, TEE_IOC_BASE + 9, \
 				     struct tee_ioctl_shm_register_data)
+
+/**
+ * struct tee_ioctl_grpc_recv_arg - Receive a request for a generic RPC function
+ * @func:	[in] generic RPC function
+ * @num_params	[in/out] number of parameters following this struct
+ *
+ * @num_params is the number of params that host application has room to
+ * receive when input, @num_params is the number of actual params
+ * host application receives when output.
+ */
+struct tee_ioctl_grpc_recv_arg {
+	__u32 key;
+	__u32 func;
+	__u32 session;
+	__u32 num_params;
+	__u32 ret;
+	
+	/* num_params tells the actual number of element in params */
+	struct tee_ioctl_param params[];
+};
+
+/**
+ * TEE_IOC_GRPC_RECV - Receive a request for a generic RPC function
+ *
+ * Takes a struct tee_ioctl_buf_data which contains a struct
+ * tee_ioctl_grpc_recv_arg followed by any array of struct tee_param
+ */
+#define TEE_IOC_GRPC_RECV	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 10, \
+				     struct tee_ioctl_buf_data)
+
+/**
+ * struct tee_ioctl_grpc_send_arg - Send a response to a received request
+ * @ret:	[out] return value
+ * @num_params	[in] number of parameters following this struct
+ */
+struct tee_ioctl_grpc_send_arg {
+	__u32 session;
+	__u32 ret;
+	__u32 num_params;
+
+	/* num_params tells the actual number of element in params */
+	struct tee_ioctl_param params[];
+};
+
+/**
+ * TEE_IOC_GRPC_SEND - Receive a request for a generic RPC function
+ *
+ * Takes a struct tee_ioctl_buf_data which contains a struct
+ * tee_ioctl_grpc_send_arg followed by any array of struct tee_param
+ */
+#define TEE_IOC_GRPC_SEND	_IOR(TEE_IOC_MAGIC, TEE_IOC_BASE + 11, \
+				     struct tee_ioctl_buf_data)
+
 /*
  * Five syscalls are used when communicating with the TEE driver.
  * open(): opens the device associated with the driver

--- a/include/uapi/linux/tee.h
+++ b/include/uapi/linux/tee.h
@@ -184,6 +184,13 @@ struct tee_ioctl_buf_data {
  */
 #define TEE_IOCTL_PARAM_ATTR_TYPE_MASK		0xff
 
+/* Meta parameter carrying extra information about the message. */
+#define TEE_IOCTL_PARAM_ATTR_META		0x100
+
+/* Mask of all known attr bits */
+#define TEE_IOCTL_PARAM_ATTR_MASK \
+	(TEE_IOCTL_PARAM_ATTR_TYPE_MASK | TEE_IOCTL_PARAM_ATTR_META)
+
 /*
  * Matches TEEC_LOGIN_* in GP TEE Client API
  * Are only defined for GP compliant TEEs


### PR DESCRIPTION
OCALL support was originally written against Linux 4.18. However, `ms-iot-grapeboard` is based off Linux 4.14. In the interim, a number of changes were made to the TEE and OP-TEE drivers, which the OP-TEE Client API depends on, which is in turn depended on by OpenEnclave's TrustZone support.

The last PR that was submitted for this purpose included code copy-pasted wholesale as a backport of those drivers. Jordan rightfully pointed that that's not how to do it. This PR instead cherry-picks all the changes to the drivers in the range `ms-iot-grapboard..v4.18` as follows:

`git rev-list --reverse ms-iot-grapeboard..v4.18 drivers/tee include/uapi/linux/tee.h include/linux/tee_drv.h`

After all those changes, the modifications made to those drivers to support OCALLs were also cherry-picked to the result.

In summary, this PR:
1. Backports the TEE and OP-TEE drivers from Linux 4.18, retaining history;
2. Adds OCALL support to said drivers.

**Note**: The changes here work in conjunction with [this PR over in ms-iot/optee_os](https://github.com/ms-iot/optee_os/pull/51) and [this PR over in ms-iot/project-kayla](https://github.com/ms-iot/project-kayla/pull/341).